### PR TITLE
Print error trace in cli

### DIFF
--- a/src/hf_endpoints_emulator/emulator.py
+++ b/src/hf_endpoints_emulator/emulator.py
@@ -9,6 +9,7 @@ from starlette.applications import Starlette
 from starlette.responses import JSONResponse, PlainTextResponse
 from starlette.routing import Route
 
+import traceback
 import typer
 import uvicorn
 
@@ -49,6 +50,7 @@ async def predict(request):
         pred = inference_handler(deserialized_body)
         return JSONResponse(pred)
     except Exception as e:
+        print(traceback.format_exc())
         return JSONResponse({"error": str(e)}, status_code=400)
 
 


### PR DESCRIPTION
This helped me a lot in debugging my endpoint deployment. I have not added it to the response so as to keep this consistent with the actual endpoint behavior. Please consider adding the trace to the error response too so that debugging actual deployments is easier too! But, at the end of the day that's a design decision for the maintainers to make. 