### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -10,9 +10,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de  # v1
         with:
           python-version: '3.x'
       - name: Install dependencies
@@ -21,7 +21,7 @@ jobs:
           pip install setuptools wheel twine
           python setup.py sdist bdist_wheel
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@c1b34028248d0c9f7d90fe29fef2122e2276ff6f  # master
         with:
           user: __token__
           password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `pypi-publish.yaml` | `actions/checkout` | `v1` | `v6.0.2` | `de0fac2e4500…` |
| `pypi-publish.yaml` | `actions/setup-python` | `v1` | `v1` | `0f07f7f75672…` |
| `pypi-publish.yaml` | `pypa/gh-action-pypi-publish` | `master` | `master` | `c1b34028248d…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#131