### PR TITLE
fix(deps): bump starlette to >=1.0.1 + migrate to ASGI lifespan

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@ VERSION = "0.1.1"
 install_requires = [
     # transformers
     "Pillow",
-    "starlette",
+    # Floor pinned to address CVE-2026-48710 (GHSA-86qp-5c8j-p5mr):
+    # Host header poisons request.url.path; path-based middleware can be bypassed.
+    "starlette>=1.0.1",
     "uvicorn",
     "typer[all]",
 ]

--- a/src/hf_endpoints_emulator/emulator.py
+++ b/src/hf_endpoints_emulator/emulator.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import sys
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from starlette.applications import Starlette
@@ -57,6 +58,14 @@ async def health(request):
     return PlainTextResponse("Ok")
 
 
+@asynccontextmanager
+async def lifespan(app):
+    # Starlette 1.0 removed on_startup / on_shutdown in favor of the
+    # ASGI lifespan protocol.
+    await some_startup_task()
+    yield
+
+
 app = app = Starlette(
     debug=True,
     routes=[
@@ -65,7 +74,7 @@ app = app = Starlette(
         Route("/", predict, methods=["POST"]),
         Route("/predict", predict, methods=["POST"]),
     ],
-    on_startup=[some_startup_task],
+    lifespan=lifespan,
 )
 
 


### PR DESCRIPTION
## Summary

Org-wide remediation for **CVE-2026-48710 / GHSA-86qp-5c8j-p5mr** in Starlette:
a malicious `Host` header can poison `request.url.path`, allowing bypass of
path-based middleware (auth, ACLs, routing decisions). Fixed in starlette 1.0.1.

## Why two commits

1. `fix(deps): pin starlette>=1.0.1` — minimal floor bump for the CVE.
2. `refactor(emulator): migrate on_startup/on_shutdown to lifespan` — required because
   Starlette 1.0 **removed** the `on_startup` / `on_shutdown` constructor kwargs in
   favor of the ASGI lifespan protocol. Without this migration, the emulator would
   crash on boot once starlette>=1.0.1 is installed.

Splitting them keeps the security-only diff trivial to cherry-pick and reverts the
refactor independently if needed.

## Changes

- `setup.py`: pin `starlette>=1.0.1` with a CVE comment.
- `src/hf_endpoints_emulator/emulator.py`:
  - Add `from contextlib import asynccontextmanager`.
  - Wrap the existing `some_startup_task()` async handler in an `@asynccontextmanager`
    `lifespan(app)` function.
  - Replace `on_startup=[some_startup_task]` with `lifespan=lifespan` in the
    `Starlette(...)` constructor.
- No lockfile (setup.py only, no uv.lock / poetry.lock).

## Path-based middleware audit

The emulator does **not** read `request.url.path` for auth or routing decisions
(`git grep request.url.path` returns nothing). Routes are defined declaratively
via `Route(...)`, so the CVE has no direct exploitation surface in this
codebase — but the bump still matters for transitive consumers and defense in
depth.

## Safety grep (Starlette 1.0-removed APIs beyond on_startup/on_shutdown)

`git grep` for `add_event_handler`, `iscoroutinefunction_or_partial`,
`@app.route`, `@app.websocket_route`, `@app.exception_handler`,
`@app.middleware`, `@app.on_event`, problematic `TemplateResponse` / `Jinja2Templates` /
`FileResponse(method=)` patterns: **no matches**. No further follow-ups needed.

## Test plan

- [ ] CI passes.
- [ ] Local smoke: `pip install -e .` then run `hf-endpoints-emulator --handler examples/<...>/handler.py`
      and `curl http://localhost:5000/health` returns `Ok`.
- [ ] `curl -X POST http://localhost:5000/predict -d '{"inputs":"hello"}'` reaches
      the user handler (proves the lifespan startup ran and `inference_handler`
      was loaded).

## Cross-reference

Org-wide audit follow-up. Reference:
- huggingface/hf-inference-sdk#70 (merged) — same CVE, same starlette pin.
- huggingface/huggingface-inference-toolkit#125 — lifespan migration pattern
  validated by integration tests (5/6 CI green incl. remote+local).
